### PR TITLE
Fix for error when driver fails to initialise in Specflow

### DIFF
--- a/Objectivity.Test.Automation.Common/DriverContext.cs
+++ b/Objectivity.Test.Automation.Common/DriverContext.cs
@@ -478,7 +478,9 @@ namespace Objectivity.Test.Automation.Common
         /// </summary>
         public void Stop()
         {
-            this.driver.Quit();
+            if (this.driver != null) {
+                this.driver.Quit();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
If the test fails to initialise the driver in specflow, the stop call triggers a null reference exception which swallows the original exception.