### PR TITLE
Removing unnecesarrily duplicated line.

### DIFF
--- a/Objectivity.Test.Automation.Common/Extensions/WebDriverExtensions.cs
+++ b/Objectivity.Test.Automation.Common/Extensions/WebDriverExtensions.cs
@@ -64,7 +64,6 @@ namespace Objectivity.Test.Automation.Common.Extensions
             webDriver.Navigate().GoToUrl(url);
 
             ApproveCertificateForInternetExplorer(webDriver);
-            ApproveCertificateForInternetExplorer(webDriver);
         }
 
         /// <summary>


### PR DESCRIPTION
Hi, I've found duplicated lines:

ApproveCertificateForInternetExplorer(webDriver);
ApproveCertificateForInternetExplorer(webDriver);

Was it intended? :-)