### PR TITLE
Possibility to add chromedriver arguments to command line

### DIFF
--- a/Objectivity.Test.Automation.Common/App.config
+++ b/Objectivity.Test.Automation.Common/App.config
@@ -7,6 +7,7 @@
     <section name="ChromePreferences" type="System.Configuration.NameValueSectionHandler"/>
     <section name="ChromeExtensions" type="System.Configuration.NameValueSectionHandler"/>
     <section name="DriverCapabilities" type="System.Configuration.NameValueSectionHandler"/>
+    <section name="ChromeArguments" type="System.Configuration.NameValueSectionHandler"/>
   </configSections>
   <appSettings>
     <!--mandatory keys-->
@@ -82,4 +83,7 @@
   <DriverCapabilities>
     <!-->add key="CapabilityName" value=""/-->
   </DriverCapabilities>
+  <ChromeArguments>
+    <!--<add key="ChromeArgument" value=""/>-->
+  </ChromeArguments>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Objectivity.Test.Automation.Common/DriverContext.cs
+++ b/Objectivity.Test.Automation.Common/DriverContext.cs
@@ -280,6 +280,7 @@ namespace Objectivity.Test.Automation.Common
                 // retrieving settings from config file
                 var chromePreferences = ConfigurationManager.GetSection("ChromePreferences") as NameValueCollection;
                 var chromeExtensions = ConfigurationManager.GetSection("ChromeExtensions") as NameValueCollection;
+                var chromeArguments = ConfigurationManager.GetSection("ChromeArguments") as NameValueCollection;
 
                 options.AddUserProfilePreference("profile.default_content_settings.popups", 0);
                 options.AddUserProfilePreference("download.default_directory", this.DownloadFolder);
@@ -340,6 +341,16 @@ namespace Objectivity.Test.Automation.Common
                     {
                         Logger.Trace(CultureInfo.CurrentCulture, "Installing extension {0}", chromeExtensions.GetKey(i));
                         options.AddExtension(chromeExtensions.GetKey(i));
+                    }
+                }
+
+                // if there are any arguments
+                if (chromeArguments != null)
+                {
+                    // loop through all of them
+                    for (var i = 0; i < chromeArguments.Count; i++)
+                    {
+                        options.AddArgument(chromeArguments.GetKey(i));
                     }
                 }
 

--- a/Objectivity.Test.Automation.Tests.Angular/App.config
+++ b/Objectivity.Test.Automation.Tests.Angular/App.config
@@ -7,6 +7,7 @@
     <section name="ChromePreferences" type="System.Configuration.NameValueSectionHandler"/>
     <section name="ChromeExtensions" type="System.Configuration.NameValueSectionHandler"/>
     <section name="DriverCapabilities" type="System.Configuration.NameValueSectionHandler"/>
+    <section name="ChromeArguments" type="System.Configuration.NameValueSectionHandler"/>
   </configSections>
   <appSettings>
     <!--mandatory keys-->
@@ -78,4 +79,7 @@
   <DriverCapabilities>
     <!-->add key="CapabilityName" value=""/-->
   </DriverCapabilities>
+  <ChromeArguments>
+    <!--<add key="ChromeArgument" value=""/>-->
+  </ChromeArguments>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Objectivity.Test.Automation.Tests.Features/App.config
+++ b/Objectivity.Test.Automation.Tests.Features/App.config
@@ -7,6 +7,7 @@
     <section name="ChromePreferences" type="System.Configuration.NameValueSectionHandler" />
     <section name="ChromeExtensions" type="System.Configuration.NameValueSectionHandler" />
     <section name="DriverCapabilities" type="System.Configuration.NameValueSectionHandler" />
+    <section name="ChromeArguments" type="System.Configuration.NameValueSectionHandler"/>
     <section name="specFlow" type="TechTalk.SpecFlow.Configuration.ConfigurationSectionHandler, TechTalk.SpecFlow" />
   </configSections>
   <appSettings>
@@ -86,6 +87,9 @@
   <DriverCapabilities>
     <!-->add key="CapabilityName" value=""/-->
   </DriverCapabilities>
+  <ChromeArguments>
+    <!--<add key="ChromeArgument" value=""/>-->
+  </ChromeArguments>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">
       <providers>

--- a/Objectivity.Test.Automation.Tests.MsTest/App.config
+++ b/Objectivity.Test.Automation.Tests.MsTest/App.config
@@ -7,6 +7,7 @@
     <section name="ChromePreferences" type="System.Configuration.NameValueSectionHandler"/>
     <section name="ChromeExtensions" type="System.Configuration.NameValueSectionHandler"/>
     <section name="DriverCapabilities" type="System.Configuration.NameValueSectionHandler"/>
+    <section name="ChromeArguments" type="System.Configuration.NameValueSectionHandler"/>
   </configSections>
   <appSettings>
     <!--mandatory keys-->
@@ -76,4 +77,7 @@
   <DriverCapabilities>
     <!-->add key="CapabilityName" value=""/-->
   </DriverCapabilities>
+  <ChromeArguments>
+    <!--<add key="ChromeArgument" value=""/>-->
+  </ChromeArguments>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Objectivity.Test.Automation.Tests.NUnit/App.config
+++ b/Objectivity.Test.Automation.Tests.NUnit/App.config
@@ -7,6 +7,7 @@
     <section name="ChromePreferences" type="System.Configuration.NameValueSectionHandler"/>
     <section name="ChromeExtensions" type="System.Configuration.NameValueSectionHandler"/>
     <section name="DriverCapabilities" type="System.Configuration.NameValueSectionHandler"/>
+    <section name="ChromeArguments" type="System.Configuration.NameValueSectionHandler"/>
   </configSections>
   <appSettings>
     <!--mandatory keys-->
@@ -78,4 +79,7 @@
   <DriverCapabilities>
     <!-->add key="CapabilityName" value=""/-->
   </DriverCapabilities>
+  <ChromeArguments>
+    <!--<add key="ChromeArgument" value=""/>-->
+  </ChromeArguments>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/Objectivity.Test.Automation.Tests.Xunit/App.config
+++ b/Objectivity.Test.Automation.Tests.Xunit/App.config
@@ -7,6 +7,7 @@
     <section name="ChromePreferences" type="System.Configuration.NameValueSectionHandler"/>
     <section name="ChromeExtensions" type="System.Configuration.NameValueSectionHandler"/>
     <section name="DriverCapabilities" type="System.Configuration.NameValueSectionHandler"/>
+    <section name="ChromeArguments" type="System.Configuration.NameValueSectionHandler"/>
   </configSections>
   <appSettings>
     <!--mandatory keys-->
@@ -80,4 +81,7 @@
   <DriverCapabilities>
     <!-->add key="CapabilityName" value=""/-->
   </DriverCapabilities>
+  <ChromeArguments>
+    <!--<add key="ChromeArgument" value=""/>-->
+  </ChromeArguments>
 </configuration>


### PR DESCRIPTION
It is possible to pass command line arguments for chrome driver i.e. add key start-maximized in ChromeArguments section in app.config to start chrome window maximized.